### PR TITLE
fix: Properly reload all caches in refresh_cache tool (v0.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the Spiritual Library MCP Server will be documented in this file.
 
+## [0.3.5] - 2025-01-25 - Fix refresh_cache Command
+
+### Fixed
+- **refresh_cache Tool**: Fixed critical bug where newly indexed documents didn't appear in searches
+  - Previously: `load_book_index()` result was not assigned, leaving stale data in memory
+  - Previously: Vector store was never reloaded, so new documents remained invisible
+  - Now: Properly reloads book index, vector store, and clears all caches
+  - **Impact**: Users can now see newly indexed documents without restarting the MCP server
+
+### Enhanced
+- **Cache Management**: refresh_cache now clears all caches comprehensively
+  - Reloads book index from disk
+  - Reloads vector store to pick up new documents
+  - Clears search cache (5-minute TTL cache)
+  - Clears category cache (5-minute TTL cache, introduced in v0.3.4)
+  - Provides detailed feedback on what was refreshed
+
+### Technical Details
+- Fixed assignment: `self.rag.book_index = self.rag.load_book_index()`
+- Added vector store reload: `self.rag.vectorstore = self.rag.initialize_vectorstore()`
+- Backward compatible: Safely handles missing `_category_cache` attribute
+- Originally reported in PR #4
+
 ## [0.3.4] - 2025-01-25 - MCP Server Query Performance
 
 ### Added

--- a/TEST_REFRESH_CACHE.md
+++ b/TEST_REFRESH_CACHE.md
@@ -1,0 +1,281 @@
+# Test Procedure: refresh_cache Fix (v0.3.5)
+
+This document provides step-by-step instructions to verify that the `refresh_cache` tool correctly picks up newly indexed documents.
+
+## Bug Being Tested
+
+**Previous Behavior**: After indexing new documents, the `refresh_cache` tool would not make them visible in searches. Users had to restart the MCP server.
+
+**Expected Fix**: After calling `refresh_cache`, newly indexed documents should immediately be searchable.
+
+---
+
+## Prerequisites
+
+1. Claude Desktop is installed and configured with the Personal Library MCP server
+2. You have access to `/Users/hpoliset/SpiritualLibrary` (your document directory)
+3. You have a test document ready (or will create one)
+
+---
+
+## Test Procedure
+
+### Phase 1: Preparation
+
+#### Step 1.1: Create a Test Document
+
+Create a simple text file with unique, searchable content:
+
+```bash
+cat > /Users/hpoliset/SpiritualLibrary/TEST_REFRESH_CACHE_$(date +%Y%m%d_%H%M%S).txt << 'EOF'
+REFRESH CACHE TEST DOCUMENT
+
+This is a test document to verify the refresh_cache functionality.
+
+Unique test phrase: XYZZY_MAGIC_REFRESH_TEST_12345
+
+This document should become searchable after calling refresh_cache
+without requiring an MCP server restart.
+
+Test timestamp: $(date)
+EOF
+```
+
+**Expected Result**: File created successfully in your library directory.
+
+#### Step 1.2: Note Current Library State
+
+Open Claude Desktop and ask:
+```
+Use the library_stats tool to show me my current library statistics
+```
+
+**Record the following**:
+- Total books: ________
+- Total chunks: ________
+- General chunks: ________
+
+---
+
+### Phase 2: Index the Test Document
+
+#### Step 2.1: Index Using Background Monitor
+
+**Option A: If background monitor is running**
+```bash
+# Wait 30-60 seconds for automatic indexing
+# Check logs:
+tail -f /Users/hpoliset/AITools/logs/index_monitor.log
+```
+
+**Option B: Manual indexing (recommended for controlled testing)**
+```bash
+export PYTHONPATH="/Users/hpoliset/AITools/src"
+./venv_mcp/bin/python -m personal_doc_library.indexing.index_documents \
+  --doc-path "/Users/hpoliset/SpiritualLibrary"
+```
+
+**Expected Result**:
+- Log shows "Processing: TEST_REFRESH_CACHE_*.txt"
+- Log shows "Successfully indexed: TEST_REFRESH_CACHE_*.txt"
+- No errors in logs
+
+#### Step 2.2: Verify Document is Indexed on Disk
+
+Check that the book index was updated:
+
+```bash
+# Check if the test file appears in book_index.json
+grep -i "TEST_REFRESH_CACHE" /Users/hpoliset/AITools/chroma_db/book_index.json
+```
+
+**Expected Result**: Should show an entry for your test document.
+
+---
+
+### Phase 3: Test BEFORE refresh_cache (Demonstrate the Bug)
+
+#### Step 3.1: Try Searching for New Document
+
+In Claude Desktop, ask:
+```
+Search my library for "XYZZY_MAGIC_REFRESH_TEST_12345"
+```
+
+**Expected Result (BUG BEHAVIOR)**:
+- ❌ No results found
+- This proves the document is indexed on disk but not loaded in the MCP server's memory
+
+#### Step 3.2: Check Library Stats Again
+
+In Claude Desktop, ask:
+```
+Use library_stats to show my current statistics
+```
+
+**Expected Result (BUG BEHAVIOR)**:
+- Total books: ________ (SAME as Step 1.2 - no change)
+- Total chunks: ________ (SAME as Step 1.2 - no change)
+- This proves the MCP server is using stale cached data
+
+---
+
+### Phase 4: Test refresh_cache (The Fix)
+
+#### Step 4.1: Call refresh_cache Tool
+
+In Claude Desktop, ask:
+```
+Use the refresh_cache tool to reload the library
+```
+
+**Expected Result (FIX WORKING)**:
+```
+✅ Cache refreshed successfully!
+
+📚 Total books: [NEW COUNT - should be +1]
+📊 Total chunks: [NEW COUNT - should be higher]
+🔄 Vector store: Reloaded
+🗑️  Search cache: Cleared
+🗑️  Category cache: Cleared
+```
+
+**Verify**:
+- ✅ Message shows "Vector store: Reloaded"
+- ✅ Message shows "Search cache: Cleared"
+- ✅ Message shows "Category cache: Cleared"
+- ✅ Book count increased by 1
+- ✅ Chunk count increased
+
+---
+
+### Phase 5: Test AFTER refresh_cache (Verify the Fix)
+
+#### Step 5.1: Search Again
+
+In Claude Desktop, ask the same query:
+```
+Search my library for "XYZZY_MAGIC_REFRESH_TEST_12345"
+```
+
+**Expected Result (FIX WORKING)**:
+- ✅ Document NOW found!
+- ✅ Results show passages containing "XYZZY_MAGIC_REFRESH_TEST_12345"
+- ✅ Source shows "TEST_REFRESH_CACHE_*.txt"
+
+#### Step 5.2: Verify Library Stats Updated
+
+In Claude Desktop, ask:
+```
+Use library_stats again to confirm the new book is counted
+```
+
+**Expected Result (FIX WORKING)**:
+- ✅ Total books: [Matches the count from Step 4.1]
+- ✅ Total chunks: [Matches the count from Step 4.1]
+- ✅ New document is now included in the statistics
+
+#### Step 5.3: Test Category Cache Clearing
+
+In Claude Desktop, ask:
+```
+Use library_stats twice in a row and show me the response times
+```
+
+**Expected Result (FIX WORKING)**:
+- First call: ~2-48 seconds (cache miss - normal)
+- Second call: <1 second (cache hit - proves category cache is working)
+- This proves the category cache was properly cleared and rebuilt
+
+---
+
+### Phase 6: Cleanup
+
+#### Step 6.1: Remove Test Document
+
+```bash
+# Find and remove test document
+rm /Users/hpoliset/SpiritualLibrary/TEST_REFRESH_CACHE_*.txt
+```
+
+#### Step 6.2: Refresh Cache Again
+
+In Claude Desktop:
+```
+Use refresh_cache to remove the test document from the index
+```
+
+**Expected Result**:
+- Book count should decrease by 1
+- Chunk count should decrease accordingly
+
+---
+
+## Test Results Summary
+
+Fill out this checklist:
+
+### Bug Demonstration (Phase 3)
+- [ ] ❌ Search before refresh_cache: Document NOT found (bug confirmed)
+- [ ] ❌ Stats before refresh_cache: Old counts shown (bug confirmed)
+
+### Fix Verification (Phase 4 & 5)
+- [ ] ✅ refresh_cache shows all clear messages
+- [ ] ✅ Search after refresh_cache: Document FOUND
+- [ ] ✅ Stats after refresh_cache: New counts shown
+- [ ] ✅ Category cache properly cleared and rebuilt
+
+### Overall Result
+- [ ] **PASS** - All tests passed, fix is working correctly
+- [ ] **FAIL** - Some tests failed (document issues below)
+
+---
+
+## Troubleshooting
+
+### Issue: Test document not indexed
+**Solution**:
+```bash
+# Manually trigger indexing
+export PYTHONPATH="/Users/hpoliset/AITools/src"
+./venv_mcp/bin/python -m personal_doc_library.indexing.index_documents \
+  --doc-path "/Users/hpoliset/SpiritualLibrary" --force
+```
+
+### Issue: refresh_cache doesn't show new messages
+**Problem**: You might be running the old code version
+**Solution**:
+```bash
+# Verify you're on the latest commit
+git log --oneline -1
+# Should show: "fix: Properly reload all caches in refresh_cache tool (v0.3.5)"
+
+# Restart Claude Desktop to pick up the new code
+```
+
+### Issue: MCP server not responding
+**Solution**:
+```bash
+# Check MCP logs
+tail -50 ~/Library/Logs/Claude/mcp-server-Personal\ Library.log
+
+# Restart Claude Desktop completely
+```
+
+---
+
+## Notes
+
+- This test creates minimal overhead (one small text file)
+- Test can be repeated multiple times safely
+- The test document is deliberately simple to ensure fast indexing
+- Always clean up test documents after testing
+
+---
+
+## Sign-off
+
+Tested by: ________________
+Date: ________________
+Result: ☐ PASS  ☐ FAIL
+Notes: ________________________________________________________________

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragdex"
-version = "0.3.4"
+version = "0.3.5"
 description = "RAG-powered document indexing and search for MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.9,<3.14"

--- a/src/personal_doc_library/servers/mcp_complete_server.py
+++ b/src/personal_doc_library/servers/mcp_complete_server.py
@@ -1158,13 +1158,27 @@ Failed: {details.get('failed', 0)}"""
             
             elif tool_name == "refresh_cache":
                 self.ensure_rag_initialized()
-                # Reload the book index
-                self.rag.load_book_index()
-                
+                # Reload the book index from disk
+                self.rag.book_index = self.rag.load_book_index()
+
+                # Reload the vector store to pick up new documents
+                logger.info("Reloading vector store...")
+                self.rag.vectorstore = self.rag.initialize_vectorstore()
+
+                # Clear the search cache
+                self.rag._search_cache.clear()
+
+                # Clear the category cache (v0.3.4+)
+                if hasattr(self.rag, '_category_cache'):
+                    self.rag._category_cache = {'counts': {}, 'timestamp': 0}
+
                 text = "✅ Cache refreshed successfully!\n\n"
                 text += f"📚 Total books: {len(self.rag.book_index)}\n"
-                text += f"📊 Total chunks: {sum(info.get('chunks', 0) for info in self.rag.book_index.values())}"
-                
+                text += f"📊 Total chunks: {sum(info.get('chunks', 0) for info in self.rag.book_index.values())}\n"
+                text += f"🔄 Vector store: Reloaded\n"
+                text += f"🗑️  Search cache: Cleared\n"
+                text += f"🗑️  Category cache: Cleared"
+
                 return {
                     "result": {
                         "content": [{"type": "text", "text": text}]


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the `refresh_cache` tool where newly indexed documents didn't appear in searches after calling `refresh_cache`. This is an enhanced version of the fix originally proposed in PR #4.

## Changes

### Core Fix
- ✅ **Fix book_index reload**: Properly assign result of `load_book_index()` instead of discarding it
- ✅ **Add vector store reload**: Reload vector store to pick up newly indexed documents
- ✅ **Clear search cache**: Clear the 5-minute TTL search cache

### Enhancements (v0.3.4 Compatibility)
- ✅ **Clear category cache**: Clear the category cache introduced in v0.3.4
- ✅ **Detailed feedback**: Show comprehensive feedback about what was refreshed
- ✅ **Test procedure**: Added TEST_REFRESH_CACHE.md with step-by-step testing instructions

## Impact

**Before**: Users had to restart the MCP server to see newly indexed documents  
**After**: Users can call `refresh_cache` and immediately see new documents in searches

## Testing

- ✅ Verified by @hpoliset that refresh_cache is working correctly
- 📋 Test procedure document included: TEST_REFRESH_CACHE.md

## Version Bump

- Version updated from 0.3.4 → 0.3.5
- CHANGELOG.md updated with detailed changes

## Related Issues

Fixes #4 (enhanced version of the original fix)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>