### PR TITLE
v0.3.7 - LaunchAgent PATH fix, --retry flag, doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the Spiritual Library MCP Server will be documented in this file.
 
+## [0.3.7] - 2026-02-24 - LaunchAgent PATH Fix, --retry Flag, Doc Fixes
+
+### Fixed
+- **LaunchAgent PATH**: macOS LaunchAgent services now include Homebrew paths (`/opt/homebrew/bin`, `/usr/local/bin`) in their environment. Previously, services ran with a minimal PATH that excluded tools like `soffice` (LibreOffice), `ebook-convert` (Calibre), and `gs` (Ghostscript), causing `.doc` and other format processing to fail.
+- **Web Monitor Retry Route**: Fixed retry button failing for books with slashes in their path (e.g., `Osho/Rasik/...`). Flask route changed from `<book_name>` to `<path:book_name>` to match full paths.
+- **CLI prog name**: Fixed `ragdex --help` displaying as `pdlib-cli` instead of `ragdex`.
+
+### Added
+- **`ragdex-index --retry` flag**: Clears the failed documents list (`failed_pdfs.json`) before starting the monitor, so all previously failed documents are re-attempted on the next sync cycle. Useful after installing missing tools like LibreOffice or Ghostscript.
+- **`ragdex --version` / `-V` flag**: Shows the installed ragdex version using package metadata.
+
+### Documentation
+- Removed references to non-existent `document-processing` pip extra; corrected to `doc-support`
+- Removed poppler-utils from optional dependencies (not used; ragdex uses pypdf and pdfminer.six)
+- Added Ghostscript as documented optional dependency for cleaning corrupted PDFs
+- Clarified that OCR requires both ocrmypdf and Tesseract, with auto-detection details
+- Marked Linux support as untested throughout all guides
+- Added "install all optional tools at once" convenience block to QUICKSTART.md
+- Added optional system dependencies table to QUICK_REFERENCE.md
+
 ## [0.3.6] - 2025-01-25 - Bug Fixes, Subfolder Search, and Pagination
 
 ### Fixed

--- a/PYPI_PUBLICATION_PLAN.md
+++ b/PYPI_PUBLICATION_PLAN.md
@@ -209,7 +209,7 @@ pip install personal-doc-library
 
 ### With optional dependencies
 ```bash
-pip install personal-doc-library[document-processing,services]
+pip install personal-doc-library[doc-support,services]
 ```
 ```
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -13,7 +13,7 @@ uv pip install ragdex
 pip install ragdex
 
 # With optional extras
-pip install ragdex[document-processing,services]
+pip install 'ragdex[doc-support,services]'
 ```
 
 ### Install from Source (Development)
@@ -24,7 +24,7 @@ cd ragdex
 pip install -e .
 
 # With optional extras
-pip install -e ".[document-processing,services]"
+pip install -e ".[doc-support,services]"
 ```
 
 ## Optional System Dependencies

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -27,6 +27,25 @@ pip install -e .
 pip install -e ".[document-processing,services]"
 ```
 
+## Optional System Dependencies
+
+These are **not required** for basic operation but enable additional format support:
+
+| Tool | Command | Purpose | Install (macOS) |
+|------|---------|---------|-----------------|
+| **Calibre** | `ebook-convert` | MOBI/AZW/AZW3 ebooks | `brew install --cask calibre` |
+| **LibreOffice** | `soffice` | Legacy `.doc` files | `brew install --cask libreoffice` |
+| **ocrmypdf** | `ocrmypdf` | OCR for scanned PDFs | `brew install ocrmypdf tesseract` |
+| **Ghostscript** | `gs` | Clean corrupted PDFs | `brew install ghostscript` |
+
+> **Note**: Poppler is **not required** — Ragdex uses pure-Python PDF libraries. Linux support is untested.
+
+```bash
+# Install all optional tools at once (macOS)
+brew install --cask calibre libreoffice
+brew install ocrmypdf tesseract ghostscript
+```
+
 ## Installation with Specific Python Version
 
 ### Using uv (Recommended)
@@ -103,6 +122,9 @@ This **indexing service** watches for changes and processes documents in the bac
 # Run manually
 ragdex-index
 
+# Clear failed documents list and re-attempt on next sync
+ragdex-index --retry
+
 # Installed as service via
 ./setup_services.sh              # PyPI installation
 ./install.sh --with-services     # Source installation
@@ -115,9 +137,17 @@ ragdex-index
 - Updates ChromaDB vector database
 - Tracks failed documents
 
+**Flags:**
+- `--retry` — Clears the failed documents list (`failed_pdfs.json`) so all previously failed files are re-attempted on the next sync cycle
+- `--daemon` — Run as background daemon process
+- `--service` — Service mode (longer delays, lower priority)
+- `--books-dir PATH` — Override document directory
+- `--db-dir PATH` — Override database directory
+
 **When to use:**
 - Install as background service for automatic indexing
 - Run manually for one-time indexing
+- Use `--retry` after installing missing tools (e.g., LibreOffice, Ghostscript) to re-process previously failed documents
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -322,17 +322,14 @@ If you already have other MCP servers, add ragdex to the existing structure:
 <summary>📦 Install with Optional Dependencies</summary>
 
 ```bash
-# Document processing extras (using uv - recommended)
-uv pip install ragdex[document-processing]
+# Legacy .doc file support (using uv - recommended)
+uv pip install --python ~/ragdex_env/bin/python 'ragdex[doc-support]'
 
-# Service management
-uv pip install ragdex[services]
+# Daemon mode for ragdex-index --daemon
+uv pip install --python ~/ragdex_env/bin/python 'ragdex[services]'
 
-# Everything
-uv pip install ragdex[document-processing,services]
-
-# Alternative: standard pip
-# pip install ragdex[document-processing,services]
+# All extras
+uv pip install --python ~/ragdex_env/bin/python 'ragdex[doc-support,services]'
 ```
 
 </details>
@@ -348,10 +345,10 @@ cd ragdex
 uv pip install -e .
 
 # With extras
-uv pip install -e ".[document-processing,services]"
+uv pip install -e ".[doc-support,services]"
 
 # Alternative: standard pip
-# pip install -e ".[document-processing,services]"
+# pip install -e ".[doc-support,services]"
 ```
 
 </details>
@@ -395,7 +392,7 @@ pkill -f ragdex 2>/dev/null || true
 uv pip install --upgrade ragdex
 
 # Or with extras
-uv pip install --upgrade ragdex[document-processing,services]
+uv pip install --upgrade 'ragdex[doc-support,services]'
 
 # Alternative: standard pip
 # pip install --upgrade ragdex

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ When enabled, Ragdex intelligently filters out noise from your email archives:
 - **Admin Access**: Required for installation - [Details →](QUICKSTART.md#1-adminsudo-access)
 
 **Optional Tools** (format-specific):
-- Calibre (MOBI/AZW ebooks), LibreOffice (.doc files), ocrmypdf (scanned PDFs)
+- Calibre (MOBI/AZW ebooks), LibreOffice (.doc files), ocrmypdf + Tesseract (scanned PDFs), Ghostscript (corrupted PDFs)
 - [See all optional dependencies →](QUICKSTART.md#-optional-dependencies-format-specific)
 
 **Run Prerequisites Check Script**: [Verification script →](QUICKSTART.md#-prerequisites-verification-script)
@@ -236,7 +236,7 @@ Having issues? Common problems and solutions:
 ### System Requirements
 
 - **Python 3.10-3.13** (3.11+ recommended for best performance)
-- **macOS** (primary) or **Linux** (Windows not yet supported)
+- **macOS** (primary, fully tested) or **Linux** (untested — community feedback welcome)
 - **8GB RAM minimum** (16GB recommended)
   - Embedding model uses ~4GB
   - Document processing can spike to 6-8GB for large PDFs
@@ -245,10 +245,11 @@ Having issues? Common problems and solutions:
   - ~2GB for embedding models (auto-downloaded on first run)
   - ~1MB per 100-page PDF for vector database storage
 - **Claude Desktop** (required for MCP integration)
-- **Optional dependencies**:
-  - Calibre (for MOBI/AZW ebooks)
-  - LibreOffice (for .doc files)
-  - ocrmypdf (for scanned PDFs)
+- **Optional system dependencies** (install via Homebrew or apt):
+  - **Calibre** — `ebook-convert` for MOBI/AZW/AZW3 ebook processing
+  - **LibreOffice** — `soffice` for legacy `.doc` file conversion
+  - **ocrmypdf + Tesseract** — OCR for scanned PDFs (auto-detected when < 20% text)
+  - **Ghostscript** — `gs` for cleaning corrupted/malformed PDFs that fail standard extraction
 
 ### Configuration Options
 
@@ -362,6 +363,7 @@ uv pip install -e ".[document-processing,services]"
 # Main commands
 ragdex-mcp            # Start MCP server
 ragdex-index          # Start background indexer
+ragdex-index --retry  # Clear failed list and re-attempt failed documents
 ragdex-web            # Launch web dashboard
 
 # Management commands

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -594,7 +594,7 @@
                         <li>CLI commands: <code>ragdex</code>, <code>ragdex-mcp</code>, <code>ragdex-index</code>, <code>ragdex-web</code></li>
                         <li>Package installation: <code>pip install ragdex</code></li>
                         <li>Development: <code>pip install -e .</code></li>
-                        <li>With extras: <code>pip install -e ".[document-processing,services]"</code></li>
+                        <li>With extras: <code>pip install -e ".[doc-support,services]"</code></li>
                     </ul>
                 </div>
 
@@ -900,7 +900,7 @@ source ~/ragdex_env/bin/activate
 pip install ragdex
 
 # With optional extras
-pip install ragdex[document-processing,services]</code></pre>
+pip install ragdex[doc-support,services]</code></pre>
 
             <h3>📦 Development Installation</h3>
             <pre><code># Clone repository
@@ -911,7 +911,7 @@ cd ragdex
 pip install -e .
 
 # Or with extras
-pip install -e ".[document-processing,services]"
+pip install -e ".[doc-support,services]"
 
 # Use CLI commands
 ragdex --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragdex"
-version = "0.3.6"
+version = "0.3.7"
 description = "RAG-powered document indexing and search for MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.9,<3.14"

--- a/setup_services.sh
+++ b/setup_services.sh
@@ -162,6 +162,11 @@ DOCS_PATH="${DOCS_PATH/#\~/$HOME}"
 DB_PATH="${DB_PATH/#\~/$HOME}"
 LOGS_PATH="${LOGS_PATH/#\~/$HOME}"
 
+# Build PATH for LaunchAgent services
+# macOS LaunchAgents get a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin),
+# so we include common tool locations (Homebrew, etc.) for soffice, ebook-convert, etc.
+LAUNCH_AGENT_PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
 # Show configuration summary
 echo ""
 echo "${BLUE}📋 Configuration Summary:${NC}"
@@ -325,6 +330,8 @@ cat > "$INDEX_PLIST" << EOF
         <string>1</string>
         <key>CHROMA_TELEMETRY</key>
         <string>false</string>
+        <key>PATH</key>
+        <string>$LAUNCH_AGENT_PATH</string>
     </dict>
 
     <key>StandardOutPath</key>
@@ -377,6 +384,8 @@ cat > "$WEB_PLIST" << EOF
         <string>1</string>
         <key>CHROMA_TELEMETRY</key>
         <string>false</string>
+        <key>PATH</key>
+        <string>$LAUNCH_AGENT_PATH</string>
     </dict>
 
     <key>StandardOutPath</key>

--- a/src/personal_doc_library/cli.py
+++ b/src/personal_doc_library/cli.py
@@ -62,8 +62,12 @@ def handle_fix_skipped_command(relative_path: str) -> int:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Entry point for the pdlib-cli command."""
-    parser = argparse.ArgumentParser(prog="pdlib-cli", description="Utilities for the Personal Document Library")
+    """Entry point for the ragdex command."""
+    from importlib.metadata import version as pkg_version
+
+    parser = argparse.ArgumentParser(prog="ragdex", description="Utilities for the Personal Document Library")
+    parser.add_argument("--version", "-V", action="version",
+                        version=f"ragdex {pkg_version('ragdex')}")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     subparsers.add_parser("config", help="Show configuration information")

--- a/src/personal_doc_library/monitoring/monitor_web_enhanced.py
+++ b/src/personal_doc_library/monitoring/monitor_web_enhanced.py
@@ -1241,7 +1241,7 @@ def api_failed_books():
     
     return jsonify(failed_books)
 
-@app.route('/api/retry/<book_name>', methods=['POST'])
+@app.route('/api/retry/<path:book_name>', methods=['POST'])
 def api_retry_book(book_name):
     """Retry indexing a failed book"""
     # This endpoint would need to be implemented with actual retry logic


### PR DESCRIPTION
## Summary

### Bug Fixes
- **LaunchAgent PATH** — macOS LaunchAgent services now include Homebrew paths (`/opt/homebrew/bin`, `/usr/local/bin`). Previously `.doc` files and other formats failed because `soffice`, `ebook-convert`, and `gs` weren't on the minimal default PATH.
- **Web Monitor Retry Route** — Fixed retry button failing for books with slashes in path. Changed Flask route from `<book_name>` to `<path:book_name>`.
- **CLI prog name** — Fixed `ragdex --help` showing `pdlib-cli` instead of `ragdex`.

### New Features
- **`ragdex-index --retry`** — Clears failed documents list before starting monitor, so previously failed files are re-attempted on next sync.
- **`ragdex --version`** — Shows installed version using package metadata.

### Documentation
- Removed non-existent `document-processing` pip extra references; corrected to `doc-support`
- Removed poppler-utils (not used — ragdex uses pypdf/pdfminer.six)
- Added Ghostscript as optional dependency for corrupted PDFs
- Clarified OCR requires both ocrmypdf + Tesseract with auto-detection
- Marked Linux support as untested throughout all guides
- Added "install all optional tools" convenience block and dependencies table

## Test plan
- [x] `ragdex --version` outputs `ragdex 0.3.7`
- [x] `ragdex-index --help` shows `--retry` flag
- [x] `ragdex-index --retry` clears failed documents list
- [x] LaunchAgent plists contain PATH with `/opt/homebrew/bin`
- [x] `.DOC` files successfully indexed via `soffice` under LaunchAgent
- [x] Web monitor retry works for books with slashes in path
- [ ] TestPyPI publication verified
- [ ] PyPI publication verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)