### PR TITLE
v0.3.9 - Large PDF progress timeout, skip UI, coding standards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragdex"
-version = "0.3.8"
+version = "0.3.9"
 description = "RAG-powered document indexing and search for MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.9,<3.14"


### PR DESCRIPTION
## Summary

- **Fix large file indexing timeout regression**: Page-dense PDFs (e.g. 199MB / 39,883 pages) were killed by the 900s size-based timeout. Now uses page-count-based timeouts (3s/page, capped at 4 hours), incremental page extraction with progress reporting every 100 pages, and scaled max_extensions (20 for >100MB files).
- **Add Skip functionality**: Users can skip failed documents from the web monitor UI (new Skip button) or CLI (`ragdex-index --skip <path>`). Skipped files stay in the failed list and won't be retried automatically.
- **Fix web monitor progress display**: Status was showing "idle" while embedding was actively running. Now detects active stages from `indexing_progress.json` and overrides the display, showing batch-level progress bars during embedding.
- **Add comprehensive coding standards**: Library-specific best practices for ChromaDB, LangChain (with deprecation migration table), sentence-transformers, pypdf, Flask, MCP, and watchdog. Documents threading vs async decision and large file handling guidelines.
- **Update installation docs**: Recommend `uvx ragdex-mcp` as primary zero-install method, with pipx and manual venv as alternatives.

## Test plan

- [x] Verified `ragdex-index --skip <path>` writes correct entry to `failed_pdfs.json`
- [x] Verified `POST /api/skip/<book_name>` endpoint works via curl
- [x] Verified Skip button appears in Failed Books tab (not shown for already-skipped entries)
- [x] Verified Retry clears skipped entries correctly
- [x] Verified page-count timeout boost: `"PDF has 39883 pages, increasing timeout from 900s to 14400s"`
- [x] Verified incremental loading: `"Loaded 100/39883 pages..."` progress every 100 pages
- [x] Verified embedding progress visible in web monitor during active indexing
- [x] Verified 39,883-page Osho PDF successfully indexes (181,574 chunks, 1816 batches)
- [x] All three modified Python files pass `py_compile` syntax check

🤖 Generated with [Claude Code](https://claude.com/claude-code)