### PR TITLE
v0.4.0 - Fix indexer crashes and false failure marking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ragdex"
-version = "0.3.9"
+version = "0.4.0"
 description = "RAG-powered document indexing and search for MCP (Model Context Protocol)"
 readme = "README.md"
 requires-python = ">=3.9,<3.14"


### PR DESCRIPTION
## Summary

- **Fix `UnboundLocalError` on `max_workers`** — `process_single_document()` and `ThreadPoolExecutor` were outside the `if regular_files` guard but referenced `max_workers` defined inside it. Moved both into the conditional block so they only execute when regular files exist.
- **Fix `Unsupported file type: .cleaned`** — `handle_failed_pdf()` named cleaned files as `file.pdf.cleaned`, causing `os.path.splitext()` to return `.cleaned` instead of `.pdf`. Changed naming to `file_cleaned.pdf` to preserve the extension.
- **Fix false failure marking after successful indexing** — Post-success cleanup errors (`remove_from_failed_list`, `cleanup_temp_file`) fell through to the `except` block which called `handle_failed_document`, marking already-indexed documents as failed. Wrapped post-success cleanup in its own `try/except`.
- **Bump version to 0.4.0**
- **Add "Updating the Indexer Service During Development"** section to CLAUDE.md with service restart and crash recovery instructions.

## Test plan

- [x] Python syntax check passes on both modified files
- [x] Indexer starts cleanly with `--retry` flag (no `UnboundLocalError`)
- [x] `os.path.splitext("file_cleaned.pdf")` returns `.pdf`
- [x] Indexer correctly skips already-indexed Osho PDF (181K chunks) on restart
- [x] LaunchAgent service starts and processes new documents without crashes
- [ ] Verify large-file-only scenario (no regular files) doesn't crash
- [ ] Verify cleaned PDF path is accepted by `get_document_loader()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)